### PR TITLE
Update Logger::asString(Level)

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -170,7 +170,9 @@ Logger& Logger::getInstance()
 
 const char* Logger::asString(Level level)
 {
-    return LOG_LEVEL_STRINGS[level];
+    char* buffer = (char*) malloc(8);
+    strcpy_P(buffer, (PGM_P)pgm_read_word(&(LOG_LEVEL_STRINGS[level])));
+    return buffer;
 }
 
 


### PR DESCRIPTION
Proper way to retrieve strings from program memory.
Reference: https://www.nongnu.org/avr-libc/user-manual/pgmspace.html